### PR TITLE
Fix FastAPI template response compatibility

### DIFF
--- a/clicodelog/__init__.py
+++ b/clicodelog/__init__.py
@@ -2,5 +2,11 @@
 CLI Code Log - Browse, inspect, and export logs from CLI-based AI coding agents.
 """
 
-__version__ = "0.2.2"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("clicodelog")
+except PackageNotFoundError:
+    __version__ = "0.2.3"
+
 __author__ = "monk1337"

--- a/clicodelog/app.py
+++ b/clicodelog/app.py
@@ -24,7 +24,13 @@ templates = Jinja2Templates(directory=str(PACKAGE_DIR / "templates"))
 
 @app.get("/", response_class=HTMLResponse)
 async def index(request: Request):
-    return templates.TemplateResponse("index.html", {"request": request})
+    # FastAPI/Starlette changed TemplateResponse to accept `request` first.
+    # Support both the current and older call styles so fresh installs and
+    # older environments render the index page correctly.
+    try:
+        return templates.TemplateResponse(request=request, name="index.html")
+    except TypeError:
+        return templates.TemplateResponse("index.html", {"request": request})
 
 
 app.include_router(router)


### PR DESCRIPTION
I was excited to try this tool, but installing it with `uv` gave me:

```text
ERROR:    Exception in ASGI application
Traceback (most recent call last):
  File "/Users/rares/.local/share/uv/tools/clicodelog/lib/python3.10/site-packages/uvicorn/protocols/http/httptools_impl.py", line 420, in run_asgi
    result = await app(  # type: ignore[func-returns-value]
  ...
  File "/Users/rares/.local/share/uv/tools/clicodelog/lib/python3.10/site-packages/jinja2/utils.py", line 515, in __getitem__
    rv = self._mapping[key]
TypeError: unhashable type: 'dict'
```

### Why this happened

- `clicodelog` declares `fastapi>=0.104.0` with no upper bound in `pyproject.toml`
- in my fresh install, `uv` resolved newer framework versions (`fastapi 0.136.0`, `starlette 1.0.0`)
- the `Jinja2Templates.TemplateResponse(...)` call signature in current versions expects `request` first, then `name`
- the app still uses the older positional style in `clicodelog/app.py`, so the context dict is misbound and eventually triggers `TypeError: unhashable type: 'dict'`

### TL;DR

> Fresh installs resolve newer FastAPI/Starlette versions than the code was written against. In current versions, `TemplateResponse` expects `request` first, so the existing positional call misbinds the context dict and crashes.

### Fix in this PR

This PR updates the index route to use the current `TemplateResponse` call style, while keeping a fallback for older environments.

I also updated `clicodelog/__init__.py` to read `__version__` from package metadata, since `pyproject.toml` is `0.2.3` but `clicodelog.__version__` was still hardcoded to `0.2.2`.